### PR TITLE
Remove old classes when compiling

### DIFF
--- a/buildscript.gradle
+++ b/buildscript.gradle
@@ -39,6 +39,7 @@ task processSources(type: Copy) {
 }
 
 compileJava {
+    new File("$projectDir", "build"+File.separator+"classes").deleteDir()
     dependsOn(processSources)
     source = processSources.destinationDir
 }


### PR DESCRIPTION
Didn't think of the fact that old classes would remain in the build folder when hotswapping. Thanks for reminding me @canitzp