### PR TITLE
Add an option to pass additional arguments to RB

### DIFF
--- a/buildscript.gradle
+++ b/buildscript.gradle
@@ -50,12 +50,18 @@ def mainClassName = "de.ellpeck.rockbottom.Main"
 task runServer(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     args = ["--unpackedModsDir", "./build/classes/main", "--server"]
+    if ( project.hasProperty("additionalArgs") ) {
+        args += Eval.me(additionalArgs)
+    }
     main = mainClassName
 }
 
 task runClient(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     args = ["--unpackedModsDir", "./build/classes/main"]
+    if ( project.hasProperty("additionalArgs") ) {
+        args += Eval.me(additionalArgs)
+    }
     main = mainClassName
 }
 


### PR DESCRIPTION
This can be used by adding arguments to the IDE's run configurations. For example:
```
-PadditionalArgs="['--logLevel', 'CONFIG']"
```